### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.order('created_at DESC')
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    # @items = Item.order('created_at DESC')
+    @items = Item.order('created_at DESC')
   end
 
   def new
@@ -14,6 +14,11 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    #item = Item.find(params[:id])
+    #@name = item.name
   end
 
   def destroy

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,7 @@
 class Item < ApplicationRecord
   belongs_to :user
   has_one_attached :image
+  has_one :purchase
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :category

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1,7 +1,4 @@
 class Purchase < ApplicationRecord
   belongs_to :user
   belongs_to :item
-
-
-
 end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1,0 +1,7 @@
+class Purchase < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+
+
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,5 @@ class User < ApplicationRecord
   end
 
   has_many :items
+  has_many :purchases
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,18 +127,14 @@
     <ul class='item-lists'>
 
     <% @items.each do |item|%>
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
         <%= link_to item_path(item) do%>
         <div class='item-img-content'>
-          <%# image_tag "item-sample.png", class: "item-img" %>
           <%= image_tag item.image, class: "item-img" %>
-          <%# 商品が売れていればsold outを表示しましょう %>
           <% if item.purchase.present? %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
           <% end %>
         </div>
         <div class='item-info'>
@@ -156,12 +152,8 @@
         <% end %>
       </li>
     <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
-        <%= link_to '#' do %>
+        <% unless @items %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>
@@ -177,8 +169,6 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,16 +123,16 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "items/new", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
     <% @items.each do |item|%>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
-        <% link_to "#" do%>
+        <%= link_to "/items/:id" do%>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
+          <%# image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
@@ -142,10 +142,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,16 +129,17 @@
     <% @items.each do |item|%>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
-        <%= link_to "/items/:id" do%>
+        <%= link_to item_path(item) do%>
         <div class='item-img-content'>
           <%# image_tag "item-sample.png", class: "item-img" %>
           <%= image_tag item.image, class: "item-img" %>
           <%# 商品が売れていればsold outを表示しましょう %>
+          <% if item.purchase.present? %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# //商品が売れていればsold outを表示しましょう %>
-
+          <% end %>
         </div>
         <div class='item-info'>
           <h3 class='item-name'>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -139,7 +139,7 @@
     </div>
     <%# /下部ボタン %>
   </div>
-  <% end %>
+    <% end %>
 
   <footer class="items-sell-footer">
     <ul class="menu">

--- a/db/migrate/20200911023404_create_purchases.rb
+++ b/db/migrate/20200911023404_create_purchases.rb
@@ -1,0 +1,9 @@
+class CreatePurchases < ActiveRecord::Migration[6.0]
+  def change
+    create_table :purchases do |t|
+      t.references :item,     null: false, foreign_key: true
+      t.references :user,     null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_08_102754) do
+ActiveRecord::Schema.define(version: 2020_09_11_023404) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -48,6 +48,15 @@ ActiveRecord::Schema.define(version: 2020_09_08_102754) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "purchases", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "item_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_purchases_on_item_id"
+    t.index ["user_id"], name: "index_purchases_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "nickname", null: false
     t.string "email", null: false
@@ -68,4 +77,6 @@ ActiveRecord::Schema.define(version: 2020_09_08_102754) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "purchases", "items"
+  add_foreign_key "purchases", "users"
 end

--- a/spec/factories/purchases.rb
+++ b/spec/factories/purchases.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :purchase do
+    
+  end
+end

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Purchase, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
What
商品一覧表示機能の実装

Why
商品出品した情報をトップ画面で一覧表示させるため。

ログアウトした状態でも商品一覧ページを見ることができる
https://gyazo.com/251511c219eeb806ef52db867926cce0

売却済みの商品は、「sold out」の文字が表示されるようになっている
https://gyazo.com/30abb32a66a7ba653021937984e49af2

出品した商品の一覧表示ができている。かつ「画像/価格/商品名」の3つの情報について表示できている
https://gyazo.com/b38519bbca99cfd72d8e46172bc62045
https://gyazo.com/f5ad7e6ec22f28779303a3bd23528949